### PR TITLE
update: 入会フォームのリンクをshortlinkに

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -34,7 +34,7 @@ function Home() {
         <ButtonCard
           title="Welcome to us"
           aboutLink="/about"
-          enrollLink="https://forms.gle/D7rD5myoo6wDbfAD7">
+          enrollLink="https://link.techuni.org/form/admission">
         </ButtonCard>
       </Container>
       <Home2 />


### PR DESCRIPTION
## update
- 入会フォームのリンクを直リンクからshortlink(link.techuni.org)に変更
  - link.techuni.orgを作ったから
  - 今後フォームを変更する時のコスト削減(いちいちHPを再deployしなくてよくなる)